### PR TITLE
Exclude TextIO from FlinkRunner integration tests

### DIFF
--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -59,6 +59,9 @@
                     org.apache.beam.sdk.testing.UsesAttemptedMetrics,
                     org.apache.beam.sdk.testing.UsesCommittedMetrics
                   </excludedGroups>
+                  <excludes>
+                    <exclude>org.apache.beam.sdk.io.TextIO</exclude>
+                  </excludes>
                   <parallel>none</parallel>
                   <failIfNoTests>true</failIfNoTests>
                   <dependenciesToScan>
@@ -92,6 +95,9 @@
                     org.apache.beam.sdk.testing.UsesAttemptedMetrics,
                     org.apache.beam.sdk.testing.UsesCommittedMetrics
                   </excludedGroups>
+                  <excludes>
+                    <exclude>org.apache.beam.sdk.io.TextIO</exclude>
+                  </excludes>
                   <parallel>none</parallel>
                   <failIfNoTests>true</failIfNoTests>
                   <dependenciesToScan>


### PR DESCRIPTION
I'm not 100% that this is the best thing to do, if there is some other simple and surgical fix. But this is how you would disable the test.

CC: @aljoscha Reuven is adding windowed text file writes, and the Flink runner's override causes some problems here. Is it still needed? Any other feedback or advice is welcome.